### PR TITLE
【サーバサイド】商品出品機能 画像はS3にアップロード

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -10,7 +10,12 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
+  #storage :file
   # storage :fog
 
   process resize_to_fit: [400, 400]

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -14,7 +14,7 @@ CarrierWave.configure do |config|
       aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       region: 'ap-northeast-1'
     }
-    config.fog_directory  = 'market-app'
-    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/market-app'
+    config.fog_directory  = 'market-app2020'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/market-app2020'
   end
 end


### PR DESCRIPTION
# What
アプリで出品商品登録の画像を登録する際に、
ローカルと本番環境で画像の保存先を分ける機能を実装する。
本番環境ではS3に保存する。

#Why
商品出品機能の画像の保存先がS3にすることは必須要件である為。