### PR TITLE
電話番号を任意から必須へ変更

### DIFF
--- a/app/views/devise/registrations/new_deliver_address.html.haml
+++ b/app/views/devise/registrations/new_deliver_address.html.haml
@@ -52,8 +52,8 @@
       .userForm__group
         .userForm__group--label
           = f.label :telephone,'電話番号',placeholder: "例）09012345678", class: 'label'
-          %span.arbitrary
-            任意
+          %span.indispensable
+            必須
         = f.text_field :telephone, class: 'userForm__group--input'
       .userForm__btn
         = f.submit "登録完了", class: 'userForm__btn--red'


### PR DESCRIPTION
# What
新規会員登録のお届け先情報ページ「電話番号」のラベルを「任意」から「必須」へ変更

# Why
9/27MTGにて変更することが決定されたため