### PR TITLE
孫要素が選択しないと編集画面がエラーになってしまうエラーを解消

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -8,6 +8,7 @@ $(function(){
   function appendChidrenBox(insertHTML){
     var childSelectHtml = '';
     childSelectHtml =  `<select id="child_category", class="category", name="item[category_id]">
+                          <option value="">選択してください</option>
                           ${insertHTML}
                         </select>`;
     $('#category_area').append(childSelectHtml);
@@ -16,6 +17,7 @@ $(function(){
   function appendGrandchidrenBox(insertHTML){
     var grandchildSelectHtml = '';
     grandchildSelectHtml = `<select id="grandchild_category", class="category" name="item[category_id]">
+                              <option value="">選択してください</option>
                               ${insertHTML}
                             </select>`;
     $('#category_area').append(grandchildSelectHtml);


### PR DESCRIPTION
# What
出品、編集画面のカテゴリ選択項目において
子要素、孫要素の選択フォーム表示に「選択してください」とデフォルトで表示される様に実装する

# Why
商品登録の際にカテゴリ項目で孫要素を選択しないと編集画面でエラーになってしまう。